### PR TITLE
Skip cleanup hook if there are no tests. More verbose logging. Moved to package.

### DIFF
--- a/src/main/scala/sbt/scct/ScctPlugin.scala
+++ b/src/main/scala/sbt/scct/ScctPlugin.scala
@@ -113,12 +113,13 @@ object ScctPlugin extends Plugin {
       ref.project +: aggregated(ref, structure)
     }
   }
+  /** Generate hook that is invoked before each tests execution. */
   def testSetup() =
     (name in Scct, baseDirectory in Scct, scalaSource in Scct, classDirectory in ScctTest, definedTests in ScctTest, scctReportDir, streams) map {
       (name, baseDirectory, scalaSource, classDirectory, definedTests, scctReportDir, streams) =>
         if (definedTests.isEmpty) {
           streams.log.debug(logPrefix(name) + "No tests found. Skip SCCT setup hook.")
-          Tests.Cleanup { () => {} }
+          Tests.Setup { () => {} }
         } else
           Tests.Setup { () =>
             val out = classDirectory / "scct.properties"
@@ -132,6 +133,7 @@ object ScctPlugin extends Plugin {
             IO.write(props, "Env for scct test run and report generation", out)
           }
     }
+  /** Generate hook that is invoked after each tests execution. */
   def testCleanup() =
     (name in Scct, classDirectory in ScctTest, definedTests in ScctTest, streams) map {
       (name, classDirectory, definedTests, streams) =>

--- a/src/main/scala/sbt/scct/ScctPlugin.scala
+++ b/src/main/scala/sbt/scct/ScctPlugin.scala
@@ -1,3 +1,5 @@
+package sbt.scct
+
 import java.util.Properties
 import sbt._
 import sbt.Keys._


### PR DESCRIPTION
@ezh 

cc----

I moved plugin to package namespace. Debugger and code validator of the Eclipse is more friendly for standard layout. Sure that other development environments will more friendly too.

Also I added more verbose logging. It is not nice if SBT hangs without any messages on intermediate subproject without tests.

Also add condition that skip cleanup if there are no tests.

If there are no tests, now it looks like:

> scct-test:test
> [debug] 
> [debug] Initial source changes: 
> [debug] removed:Set()
> ...
> [debug] Subclass fingerprints: Stream((org.scalatest.Suite,false,org.scalatest.tools.ScalaTestFramework$$anon$1@2f32d1f2), ?)
> [debug] Annotation fingerprints: Stream((org.scalatest.WrapWith,false,org.scalatest.tools.ScalaTestFramework$$anon$2@31757f13), ?)
> [debug] scct: [Digi-Lib] No tests found. Skip SCCT setup hook.
> [debug] scct: [Digi-Lib] No tests found. Skip SCCT cleanup hook.
> [info] No tests to run for scct-test:test
> [success] Total time: 0 s, completed 19.05.2013 8:21:14
> And if there are tests:

[info] Passed: : Total 9, Failed 0, Errors 0, Passed 9, Skipped 0
[debug] scct: [Digi-Lib] Waiting for coverage report generation.
scct: [Digi-Lib] Generating coverage report.
[debug] scct: [Digi-Lib] Cleanup SCCT environment
[debug] Passed tests:
If you are not interested in theres changes please give me a note.

Thank you,
Alexey

---

https://github.com/mtkopone/sbt-scct/pull/4
