### PR TITLE
Added resourceDirectory to ScctTest

### DIFF
--- a/src/main/scala/ScctPlugin.scala
+++ b/src/main/scala/ScctPlugin.scala
@@ -41,6 +41,8 @@ object ScctPlugin extends Plugin {
       sources in ScctTest <<= (sources in Test),
       sourceDirectory in ScctTest <<= (sourceDirectory in Test),
 
+      resourceDirectory in ScctTest <<= (resourceDirectory in Compile),
+
       externalDependencyClasspath in Scct <<= Classpaths.concat(externalDependencyClasspath in Scct, externalDependencyClasspath in Compile),
       externalDependencyClasspath in ScctTest <<= Classpaths.concat(externalDependencyClasspath in ScctTest, externalDependencyClasspath in Test),
 


### PR DESCRIPTION
@bancek 

cc---

I'm using scct with Play Framework. Play stores all configuration in conf/ directory which is added to resourceDirectory in Compile. Play configuration file and plugins (e.g. play-salat) won't load without this.
