### PR TITLE
Add crossbulding for SBT 0.12 and 0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,15 @@ name := "sbt-scct"
 
 version := "0.2-SNAPSHOT"
 
-//scalaVersion := "2.10.0-RC3" (not yet, sbt itself uses 2.9)
-scalaVersion := "2.9.2"
+scalaVersion := "2.10.2"
 
-crossScalaVersions := Seq("2.10.0-RC3", "2.9.2", "2.9.1-1", "2.9.1", "2.9.0-1", "2.9.0")
+crossScalaVersions := Seq("2.10.2", "2.9.2", "2.9.1-1", "2.9.1", "2.9.0-1", "2.9.0")
 
 sbtPlugin := true
+
+crossBuildingSettings
+
+CrossBuilding.crossSbtVersions := Seq("0.12", "0.13")
 
 // Load scct from remote:
 resolvers += "scct-github-repository" at "http://mtkopone.github.com/scct/maven-repo"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.0")


### PR DESCRIPTION
Requires this change in SCCT: https://github.com/SCCT/scct/pull/7

Cross publish for SBT 0.12 and 0.13 with the command `^publish`. See [sbt-cross-building](https://github.com/jrudolph/sbt-cross-building) for more details.

When testing locally I had to change `seq(ScctPlugin.instrumentSettings : _*)` to `seq(sbt.scct.ScctPlugin.instrumentSettings : _*)`
