### PR TITLE
Update scct deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ crossBuildingSettings
 CrossBuilding.crossSbtVersions := Seq("0.12", "0.13")
 
 // Load scct from remote:
-resolvers += "scct-github-repository" at "http://scct.github.com/scct/maven-repo"
+resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-libraryDependencies += "reaktor" %% "scct" % "0.2-SNAPSHOT"
+libraryDependencies += "com.github.scct" %% "scct" % "0.2-SNAPSHOT"
 
 publishTo <<= version { (v: String) =>
   val nexus = "https://oss.sonatype.org/"

--- a/src/main/scala/sbt/scct/ScctPlugin.scala
+++ b/src/main/scala/sbt/scct/ScctPlugin.scala
@@ -23,9 +23,9 @@ object ScctPlugin extends Plugin {
       // Local dev:
       // resolvers += "scct-repository" at "file:///Users/mtkopone/dev/scct-root/gh-pages/maven-repo",
       // Actual usage:
-      resolvers += "scct-repository" at "http://mtkopone.github.com/scct/maven-repo",
+      resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/snapshots",
 
-      libraryDependencies += "reaktor" %% "scct" % "0.2-SNAPSHOT" % "scct",
+      libraryDependencies += "com.github.scct" %% "scct" % "0.2-SNAPSHOT" % "scct",
 
       sources in Scct <<= (sources in Compile),
       sourceDirectory in Scct <<= (sourceDirectory in Compile),


### PR DESCRIPTION
This this only currently builds with for sbt 0.13 with:

```
^^0.13.0
publish
```

To build for both sbt 0.12 and 0.13 with this command we need scct published for scala 2.9:

```
^publish
```

scct is currently only published for 2.10: https://oss.sonatype.org/content/repositories/snapshots/com/github/scct/
