### PR TITLE
Include resource files in scct:test

### DIFF
--- a/src/main/scala/ScctPlugin.scala
+++ b/src/main/scala/ScctPlugin.scala
@@ -41,6 +41,7 @@ object ScctPlugin extends Plugin {
 
       sources in ScctTest <<= (sources in Test),
       sourceDirectory in ScctTest <<= (sourceDirectory in Test),
+      unmanagedResources in ScctTest <<= (unmanagedResources in Test),
 
       resourceDirectory in ScctTest <<= (resourceDirectory in Compile),
 


### PR DESCRIPTION
I reported in SCCT/scct#21 about test resources being ignored after instrumentation, causing tests to report errors inconsistently if they require resources (such as config files).

This allows for user-defined resources to be included in scct:test runs.
