### PR TITLE
Exclude by full class name (package + name) or by file path (relative to base dir).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 project/build/target/
 target/
+.idea
+.idea_modules

--- a/src/main/scala/ScctPlugin.scala
+++ b/src/main/scala/ScctPlugin.scala
@@ -8,6 +8,7 @@ object ScctPlugin extends Plugin {
   val scctReportDir = SettingKey[File]("scct-report-dir")
 
   val scctExcludePackages = SettingKey[String]("scct-exclude-package")
+  val scctExcludeFiles = SettingKey[String]("scct-exclude-files")
 
   lazy val Scct = config("scct")
   lazy val ScctTest = config("scct-test") extend Scct
@@ -18,6 +19,7 @@ object ScctPlugin extends Plugin {
     Seq(
       scctReportDir <<= crossTarget / "coverage-report",
       scctExcludePackages <<= scctExcludePackages ?? "",
+      scctExcludeFiles <<= scctExcludeFiles ?? "",
 
       ivyConfigurations ++= Seq(Scct, ScctTest),
 
@@ -119,8 +121,17 @@ object ScctPlugin extends Plugin {
   }
   /** Generate hook that is invoked before each tests execution. */
   def testSetup() =
-    (name in Scct, baseDirectory in Scct, scalaSource in Scct, classDirectory in ScctTest, scctExcludePackages in ScctTest, definedTests in ScctTest, scctReportDir, streams) map {
-      (name, baseDirectory, scalaSource, classDirectory, scctExcludePackages, definedTests, scctReportDir, streams) =>
+    ( name                in Scct,
+      baseDirectory       in Scct,
+      scalaSource         in Scct,
+      classDirectory      in ScctTest,
+      scctExcludePackages in ScctTest,
+      scctExcludeFiles    in ScctTest,
+      definedTests        in ScctTest,
+      scctReportDir,
+      streams) map {
+      (name, baseDirectory, scalaSource, classDirectory, scctExcludePackages, scctExcludeFiles, definedTests,
+       scctReportDir, streams) =>
         if (definedTests.isEmpty) {
           streams.log.debug(logPrefix(name) + "No tests found. Skip SCCT setup hook.")
           Tests.Setup { () => {} }
@@ -134,7 +145,8 @@ object ScctPlugin extends Plugin {
             props.setProperty("scct.project.name", name)
             props.setProperty("scct.report.dir", scctReportDir.getAbsolutePath)
             props.setProperty("scct.source.dir", scalaSource.getAbsolutePath)
-            props.setProperty("scct.excluded.paths.regex", scctExcludePackages.configuration.getOrElse(""))
+            props.setProperty("scct.excluded.classes.regex", scctExcludePackages.configuration.getOrElse(""))
+            props.setProperty("scct.excluded.paths.regex", scctExcludeFiles.configuration.getOrElse(""))
             IO.write(props, "Env for scct test run and report generation", out)
           }
     }

--- a/src/main/scala/ScctPlugin.scala
+++ b/src/main/scala/ScctPlugin.scala
@@ -145,8 +145,8 @@ object ScctPlugin extends Plugin {
             props.setProperty("scct.project.name", name)
             props.setProperty("scct.report.dir", scctReportDir.getAbsolutePath)
             props.setProperty("scct.source.dir", scalaSource.getAbsolutePath)
-            props.setProperty("scct.excluded.classes.regex", scctExcludePackages.configuration.getOrElse(""))
-            props.setProperty("scct.excluded.paths.regex", scctExcludeFiles.configuration.getOrElse(""))
+            props.setProperty("scct.excluded.classes.regex", scctExcludePackages)
+            props.setProperty("scct.excluded.paths.regex", scctExcludeFiles)
             IO.write(props, "Env for scct test run and report generation", out)
           }
     }


### PR DESCRIPTION
Update related to SCCT changes. New setting has been added as well:

// Exclude by full class name (package + class name)
ScctPlugin.scctExcludePackages in ScctPlugin.ScctTest := "Reverse_,views_,AppLoader*,<root>,manual"

// Exclude by relative file path
ScctPlugin.scctExcludeFiles in ScctPlugin.ScctTest := "app/logic/user_account*"
