### PR TITLE
Removing a compile-time dependency on scct

### DIFF
--- a/src/main/scala/ScctPlugin.scala
+++ b/src/main/scala/ScctPlugin.scala
@@ -26,18 +26,19 @@ object ScctPlugin extends Plugin {
       //resolvers += Resolver.url("local-ivy", new URL("file://" + Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/snapshots",
 
-      libraryDependencies += "com.sqality.scct" %% "scct" % "0.3.1-SNAPSHOT" % "scct",
+      unmanagedJars in Scct ++= {
+        Seq(new File(scctJarPath)).classpath
+      }
 
       sources in Scct <<= (sources in Compile),
       sourceDirectory in Scct <<= (sourceDirectory in Compile),
       unmanagedResources in Scct <<= (unmanagedResources in Compile),
       resourceDirectory in Scct <<= (resourceDirectory in Compile),
 
-      scalacOptions in Scct <++= (name in Scct, baseDirectory in Scct, update) map { (n, b, report) =>
-        val pluginClasspath = report matching configurationFilter("scct")
-        if (pluginClasspath.isEmpty) throw new Exception("Fatal: scct not in libraryDependencies. Use e.g. <+= or <++= instead of <<=")
+      scalacOptions in Scct <++= (name in Scct, baseDirectory in Scct) map { (n, b) =>
+        val pluginClasspath = scctJarPath
         Seq(
-          "-Xplugin:" + pluginClasspath.head.getAbsolutePath,
+          "-Xplugin:" + pluginClasspath,
           "-P:scct:projectId:" + n,
           "-P:scct:basedir:" + b
         )

--- a/src/main/scala/ScctPlugin.scala
+++ b/src/main/scala/ScctPlugin.scala
@@ -28,7 +28,7 @@ object ScctPlugin extends Plugin {
 
       unmanagedJars in Scct ++= {
         Seq(new File(scctJarPath)).classpath
-      }
+      },
 
       sources in Scct <<= (sources in Compile),
       sourceDirectory in Scct <<= (sourceDirectory in Compile),


### PR DESCRIPTION
Currently, when using the sbt-scct plugin, scct is added as a normal library dependency, hence ending up on the classpath the the code is run.

However, the scct jar is only needed when running the test:scct task. The changes cause the scct jar to be added to the classpath only in the scct scope. 
